### PR TITLE
Add tests for pages without them

### DIFF
--- a/pages/index.test.js
+++ b/pages/index.test.js
@@ -2,6 +2,22 @@ describe(`layout`, function() {
 
   describe(`Main Nav`, function() {
 
+    it(`About`, function() {
+      cy.visit(`/`)
+      cy.contains(`.navbar a`, `About`)
+      .click()
+      cy.url().should(`include`, `/about`)
+      cy.contains(`h1`, `About`)
+    })
+
+    it(`Dictionaries`, function() {
+      cy.visit(`/`)
+      cy.contains(`.navbar a`, `Dictionaries`)
+      .click()
+      cy.url().should(`include`, `/dictionaries`)
+      cy.contains(`h1`, `Dictionaries`)
+    })
+
     it(`Home`, function() {
       cy.visit(`/languages`)
       cy.contains(`.navbar a`, `Home`)
@@ -15,6 +31,14 @@ describe(`layout`, function() {
       .click()
       cy.url().should(`include`, `/languages`)
       cy.contains(`h1`, `Languages`)
+    })
+
+    it(`Projects`, function() {
+      cy.visit(`/`)
+      cy.contains(`.navbar a`, `Projects`)
+      .click()
+      cy.url().should(`include`, `/projects`)
+      cy.contains(`h1`, `Projects`)
     })
 
   })


### PR DESCRIPTION
**Related Issue:**
closes #142 
**Description of Changes**
Add tests for pages without them. 404 pages and 500 pages are not tested in index.test.js because the only way to get error pages are tested in their unit tests.